### PR TITLE
Refactoring query mapping

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -2,6 +2,10 @@ server:
     port: 8888
 
 spring:
+  data:
+    jdbc:
+      repositories:
+        enabled: false
   jmx:
     enabled: false
   jpa:

--- a/src/main/java/it/gdhi/repository/ICategoryRepository.java
+++ b/src/main/java/it/gdhi/repository/ICategoryRepository.java
@@ -2,7 +2,6 @@ package it.gdhi.repository;
 
 import it.gdhi.model.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,8 +9,5 @@ import java.util.List;
 @Repository
 public interface ICategoryRepository extends JpaRepository<Category, Long> {
 
-    @Query("SELECT c from Category c order by c.id")
-    List<Category> findAll();
-
+    List<Category> findAllByOrderById();
 }
-

--- a/src/main/java/it/gdhi/repository/ICountrySummaryRepository.java
+++ b/src/main/java/it/gdhi/repository/ICountrySummaryRepository.java
@@ -39,7 +39,6 @@ public interface ICountrySummaryRepository extends JpaRepository<CountrySummary,
             "c.countrySummaryId.countryId = UPPER(?1)")
     List<String> getAllStatus(String countryId);
 
-    @Query("select c from CountrySummary c order by c.updatedAt desc")
-    List<CountrySummary> getAll();
+    List<CountrySummary> findAllByOrderByUpdatedAtDesc();
 
 }

--- a/src/main/java/it/gdhi/repository/IDevelopmentIndicatorRepository.java
+++ b/src/main/java/it/gdhi/repository/IDevelopmentIndicatorRepository.java
@@ -2,18 +2,11 @@ package it.gdhi.repository;
 
 import it.gdhi.model.DevelopmentIndicator;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 @Repository
 public interface IDevelopmentIndicatorRepository extends JpaRepository<DevelopmentIndicator, Long> {
 
-    List<DevelopmentIndicator> findAll();
-
-    DevelopmentIndicator save(DevelopmentIndicator developmentIndicator);
-
-    @Query("SELECT d FROM DevelopmentIndicator d WHERE d.countryId = ?1")
     Optional<DevelopmentIndicator> findByCountryId(String countryCode);
 }

--- a/src/main/java/it/gdhi/repository/IPhaseRepository.java
+++ b/src/main/java/it/gdhi/repository/IPhaseRepository.java
@@ -2,13 +2,11 @@ package it.gdhi.repository;
 
 import it.gdhi.model.Phase;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 @Repository
 public interface IPhaseRepository extends JpaRepository<Phase, Integer> {
 
-    @Query("SELECT p from Phase p order by p.phaseId asc")
-    List<Phase> findAll();
+    List<Phase> findAllByOrderByPhaseIdAsc();
 }

--- a/src/main/java/it/gdhi/service/CategoryIndicatorService.java
+++ b/src/main/java/it/gdhi/service/CategoryIndicatorService.java
@@ -28,14 +28,14 @@ public class CategoryIndicatorService {
     }
 
     public List<CategoryIndicatorDto> getHealthIndicatorOptions(LanguageCode languageCode) {
-        return iCategoryRepository.findAll().stream()
-                                    .map(CategoryIndicatorDto::new)
-                                    .map(dto -> translator.translateHealthIndicatorOptions(dto, languageCode))
-                                    .collect(toList());
+        return iCategoryRepository.findAllByOrderById().stream()
+                .map(CategoryIndicatorDto::new)
+                .map(dto -> translator.translateHealthIndicatorOptions(dto, languageCode))
+                .collect(toList());
     }
 
     Integer getHealthIndicatorCount() {
-        List<Category> categoryList = iCategoryRepository.findAll();
+        List<Category> categoryList = iCategoryRepository.findAllByOrderById();
         AtomicInteger count = new AtomicInteger(0);
 
         categoryList.stream().forEach(category -> count.addAndGet(category.getIndicators().size()));

--- a/src/main/java/it/gdhi/service/CountryHealthDataService.java
+++ b/src/main/java/it/gdhi/service/CountryHealthDataService.java
@@ -115,7 +115,7 @@ public class CountryHealthDataService {
     }
 
     public Map<String, List<CountrySummaryStatusDto>> getAllCountryStatusSummaries() {
-        List<CountrySummary> countrySummaries = iCountrySummaryRepository.getAll();
+        List<CountrySummary> countrySummaries = iCountrySummaryRepository.findAllByOrderByUpdatedAtDesc();
 
         List<CountrySummaryStatusDto> countrySummaryStatusDtos = countrySummaries
                 .stream().map(CountrySummaryStatusDto::new).collect(toList());

--- a/src/main/java/it/gdhi/service/ExcelUtilService.java
+++ b/src/main/java/it/gdhi/service/ExcelUtilService.java
@@ -71,7 +71,7 @@ public class ExcelUtilService {
 
     void convertListToExcel(List<CountryHealthScoreDto> countryHealthScoreDtos, LanguageCode languageCode) {
         this.languageCode = languageCode;
-        List<Category> categories = iCategoryRepository.findAll();
+        List<Category> categories = iCategoryRepository.findAllByOrderById();
 
         try {
             XSSFWorkbook workbook = new XSSFWorkbook();
@@ -83,7 +83,7 @@ public class ExcelUtilService {
             Map<String, String> headerDefinitions = populateHeaderDefinitions(workbook, sheet, rownum++, categories);
             if (countryHealthScoreDtos != null && !countryHealthScoreDtos.isEmpty()) {
                 populateHealthIndicatorsWithDefinitionsAndScores(sheet, countryHealthScoreDtos,
-                                                                 headerDefinitions, rownum);
+                        headerDefinitions, rownum);
             }
             for(int i = 0; i<= noOfColumns; i++) {
                 sheet.autoSizeColumn(i);
@@ -108,9 +108,9 @@ public class ExcelUtilService {
         categories.forEach(category -> {
             category.getIndicators()
                     .forEach(indicator -> headerDef.put(  INDICATOR + indicator.getIndicatorId(),
-                                                          indicatorHeading + indicator.getCode()));
+                            indicatorHeading + indicator.getCode()));
             headerDef.put(  CATEGORY + category.getId(),
-                            categoryHeading + category.getId());
+                    categoryHeading + category.getId());
         });
         Row row = sheet.createRow(rownum);
         addRow(headerDef, row, getFontStyle(workBook));
@@ -121,9 +121,9 @@ public class ExcelUtilService {
     Map<String, String> populateHeaderDefinitions(XSSFWorkbook workBook, XSSFSheet sheet, int rownum,
                                                   List<Category> categories) {
         Map<Integer, String> categoryNameTranslations = getTranslatedCategories().stream()
-                                    .collect(toMap(CategoryTranslation::getCategoryId, CategoryTranslation::getName));
+                .collect(toMap(CategoryTranslation::getCategoryId, CategoryTranslation::getName));
         Map<Integer, String> indicatorNameTranslations = getTranslatedIndicators().stream()
-                                .collect(toMap(IndicatorTranslation::getIndicatorId, IndicatorTranslation::getName));
+                .collect(toMap(IndicatorTranslation::getIndicatorId, IndicatorTranslation::getName));
 
         Map<String, String> headerDef = new LinkedHashMap<>();
         headerDef.put(COUNTRY_NAME, translateCOUNTRYNAME());
@@ -131,7 +131,7 @@ public class ExcelUtilService {
         categories.forEach(category -> {
             category.getIndicators()
                     .forEach(indicator -> headerDef.put(INDICATOR + indicator.getIndicatorId(),
-                                                        indicatorNameTranslations.get(indicator.getIndicatorId())));
+                            indicatorNameTranslations.get(indicator.getIndicatorId())));
             headerDef.put(CATEGORY + category.getId(), categoryNameTranslations.get(category.getId()));
         });
 
@@ -158,13 +158,13 @@ public class ExcelUtilService {
                 List<IndicatorScoreDto> indicators = category.getIndicators();
                 for (IndicatorScoreDto indicator : indicators) {
                     content.put(INDICATOR + indicator.getId(),
-                                    isValidScore(indicator) ? translatePHASE() + indicator.getScore()
-                                                            : translateNOTAVAILABLE());
+                            isValidScore(indicator) ? translatePHASE() + indicator.getScore()
+                                    : translateNOTAVAILABLE());
 
                 }
                 content.put(CATEGORY + category.getId(),
-                                category.getPhase() != null ? translatePHASE() + category.getPhase()
-                                                            : translateNOTAVAILABLE());
+                        category.getPhase() != null ? translatePHASE() + category.getPhase()
+                                : translateNOTAVAILABLE());
             }
             content.put(OVERALL_PHASE, countryHealthScoreDto.getCountryPhase() != null ?
                     translatePHASE() + countryHealthScoreDto.getCountryPhase() : translateNOTAVAILABLE());

--- a/src/main/java/it/gdhi/service/PhaseService.java
+++ b/src/main/java/it/gdhi/service/PhaseService.java
@@ -15,7 +15,7 @@ public class PhaseService {
     private IPhaseRepository iPhaseRepository;
 
     public List<PhaseDto> getPhaseOptions() {
-        return iPhaseRepository.findAll().stream()
+        return iPhaseRepository.findAllByOrderByPhaseIdAsc().stream()
                 .map(phase -> new PhaseDto(phase.getPhaseName(),phase.getPhaseValue()))
                 .collect(Collectors.toList());
     }

--- a/src/test/java/it/gdhi/repository/ICategoryRepositoryTest.java
+++ b/src/test/java/it/gdhi/repository/ICategoryRepositoryTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @ActiveProfiles("test")
 public class ICategoryRepositoryTest {
     @Autowired
-    ICategoryRepository categoryRepository;
+    ICategoryRepository iCategoryRepository;
     @Autowired
     private EntityManager entityManager;
 
@@ -62,7 +62,7 @@ public class ICategoryRepositoryTest {
         entityManager.flush();
         entityManager.clear();
 
-        List<Category> categories = categoryRepository.findAll();
+        List<Category> categories = iCategoryRepository.findAllByOrderById();
         assertEquals(9, categories.size());
         Category category = categories.get(8);
         assertThat(category.getName(), is(category9.getName()));

--- a/src/test/java/it/gdhi/repository/ICountrySummaryRepositoryTest.java
+++ b/src/test/java/it/gdhi/repository/ICountrySummaryRepositoryTest.java
@@ -174,7 +174,7 @@ public class ICountrySummaryRepositoryTest {
                 "IN","IND summary", new ArrayList<>(), PUBLISHED.toString());
         addCountrySummary(countryId, "INDIA",
                 "IN","IND summary", new ArrayList<>(), NEW.toString());
-        List<CountrySummary> countrySummaries = iCountrySummaryRepository.getAll();
+        List<CountrySummary> countrySummaries = iCountrySummaryRepository.findAllByOrderByUpdatedAtDesc();
         assertEquals(countrySummaries.size(),2);
     }
 }

--- a/src/test/java/it/gdhi/service/CategoryIndicatorServiceTest.java
+++ b/src/test/java/it/gdhi/service/CategoryIndicatorServiceTest.java
@@ -48,7 +48,7 @@ public class CategoryIndicatorServiceTest {
         CategoryIndicatorDto categoryIndicator1 = new CategoryIndicatorDto(category1);
         CategoryIndicatorDto categoryIndicator2 = new CategoryIndicatorDto(category2);
 
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
         when(translator.translateHealthIndicatorOptions(categoryIndicator1, en)).thenReturn(categoryIndicator1);
         when(translator.translateHealthIndicatorOptions(categoryIndicator2, en)).thenReturn(categoryIndicator2);
 
@@ -85,7 +85,7 @@ public class CategoryIndicatorServiceTest {
         CategoryIndicatorDto categoryIndicator1 = new CategoryIndicatorDto(category1);
         CategoryIndicatorDto categoryIndicator2 = new CategoryIndicatorDto(category2);
 
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
         when(translator.translateHealthIndicatorOptions(categoryIndicator1, en)).thenReturn(categoryIndicator1);
         when(translator.translateHealthIndicatorOptions(categoryIndicator2, en)).thenReturn(categoryIndicator2);
 
@@ -121,14 +121,14 @@ public class CategoryIndicatorServiceTest {
         Category category2 = Category.builder().id(4).name("Cat 4").indicators(asList(indicator3, indicator4)).build();
 
         List<Category> categories = asList(category1, category2);
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
         CategoryIndicatorDto categoryIndicator1 = new CategoryIndicatorDto(category1);
         CategoryIndicatorDto categoryIndicator2 = new CategoryIndicatorDto(category2);
         when(translator.translateHealthIndicatorOptions(categoryIndicator1, en)).thenReturn(categoryIndicator1);
         when(translator.translateHealthIndicatorOptions(categoryIndicator2, en)).thenReturn(categoryIndicator2);
 
 
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
 
         List<CategoryIndicatorDto> categoryIndicatorMapping = categoryIndicatorService.getHealthIndicatorOptions(en);
         assertThat(categoryIndicatorMapping.size(), is(2));
@@ -158,7 +158,7 @@ public class CategoryIndicatorServiceTest {
     public void shouldHandleNullIndicatorsForACategory() {
 
         Category category1 = Category.builder().id(1).name("Cat 1").indicators(null).build();
-        when(iCategoryRepository.findAll()).thenReturn(asList(category1));
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(asList(category1));
         CategoryIndicatorDto categoryIndicator1 = new CategoryIndicatorDto(category1);
         when(translator.translateHealthIndicatorOptions(categoryIndicator1, en)).thenReturn(categoryIndicator1);
 
@@ -179,7 +179,7 @@ public class CategoryIndicatorServiceTest {
 
 
         List<Category> categories= asList(categoryEN);
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
         when(translator.translateHealthIndicatorOptions(categoryIndicatorEN, pt)).thenReturn(categoryIndicatorPT);
 
         List<CategoryIndicatorDto> healthIndicatorOptions = categoryIndicatorService.getHealthIndicatorOptions(pt);

--- a/src/test/java/it/gdhi/service/CountryHealthDataServiceTest.java
+++ b/src/test/java/it/gdhi/service/CountryHealthDataServiceTest.java
@@ -245,7 +245,7 @@ public class CountryHealthDataServiceTest {
         CountrySummary countrySummaryINDNEW = getCountrySummary("IND","NEW","INDIA",
                 "IN","Contact Name 1","con1@gdhi.com");
 
-        when(iCountrySummaryRepository.getAll()).thenReturn(asList(countrySummaryIND,countrySummaryARG,
+        when(iCountrySummaryRepository.findAllByOrderByUpdatedAtDesc()).thenReturn(asList(countrySummaryIND,countrySummaryARG,
                 countrySummaryALG,countrySummaryINDNEW));
         Map<String, List<CountrySummaryStatusDto>> adminViewFormDetails = countryHealthDataService.getAllCountryStatusSummaries();
         assertEquals(adminViewFormDetails.get("NEW").size(), 2);

--- a/src/test/java/it/gdhi/service/ExcelUtilServiceTest.java
+++ b/src/test/java/it/gdhi/service/ExcelUtilServiceTest.java
@@ -86,7 +86,7 @@ public class ExcelUtilServiceTest {
         List<Indicator> indicators = singletonList(new Indicator(1, "Ind 1", "Ind Def 1", 1));
         List<Category> categories = singletonList(new Category(1, "Cat 1",
                 indicators));
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
 
         CategoryTranslation categoryTranslation = new CategoryTranslation(new CategoryTranslationId(1, fr), "Cat 1", categories.get(0));
         IndicatorTranslation indicatorTranslation = new IndicatorTranslation(new HealthIndicatorTranslationId(1, fr), "Ind 1", "Ind Def 1", indicators.get(0));
@@ -112,7 +112,7 @@ public class ExcelUtilServiceTest {
         List<Indicator> indicators = singletonList(new Indicator(1, "Ind 1", "Ind Def 1", 1));
         List<Category> categories = singletonList(new Category(1, "Cat 1",
                 indicators));
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
 
         CategoryTranslation categoryTranslation = new CategoryTranslation(new CategoryTranslationId(1, fr), "Cat 1", categories.get(0));
         IndicatorTranslation indicatorTranslation = new IndicatorTranslation(new HealthIndicatorTranslationId(1, fr), "Ind 1", "Ind Def 1", indicators.get(0));
@@ -138,7 +138,7 @@ public class ExcelUtilServiceTest {
         List<Indicator> indicators = singletonList(new Indicator(1, "Ind 1", "Ind Def 1", 1));
         List<Category> categories = singletonList(new Category(1, "Cat 1", indicators));
 
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
 
         CategoryTranslation categoryTranslation = new CategoryTranslation(new CategoryTranslationId(1, fr), "Cat 1", categories.get(0));
         IndicatorTranslation indicatorTranslation = new IndicatorTranslation(new HealthIndicatorTranslationId(1, fr), "Ind 1", "Ind Def 1", indicators.get(0));
@@ -205,7 +205,7 @@ public class ExcelUtilServiceTest {
         List<Indicator> indicators = singletonList(new Indicator(1, "Ind 1", "Ind Def 1", 1));
         List<Category> categories = singletonList(new Category(1, "Cat 1", indicators));
 
-        when(iCategoryRepository.findAll()).thenReturn(categories);
+        when(iCategoryRepository.findAllByOrderById()).thenReturn(categories);
 
         CategoryTranslation categoryTranslation = new CategoryTranslation(new CategoryTranslationId(1, fr), "Cat 1 fr", categories.get(0));
         IndicatorTranslation indicatorTranslation = new IndicatorTranslation(new HealthIndicatorTranslationId(1, fr), "Ind 1 fr", "Ind Def 1 fr", indicators.get(0));

--- a/src/test/java/it/gdhi/service/PhaseServiceTest.java
+++ b/src/test/java/it/gdhi/service/PhaseServiceTest.java
@@ -31,7 +31,7 @@ public class PhaseServiceTest {
         Phase phase2 = new Phase(2,"phase 2 ", 2);
         Phase phase3 = new Phase(3,"phase 3 ", 3);
 
-        when(iPhaseRepository.findAll()).thenReturn(Arrays.asList(phase1,phase2,phase3));
+        when(iPhaseRepository.findAllByOrderByPhaseIdAsc()).thenReturn(Arrays.asList(phase1,phase2,phase3));
 
         List<PhaseDto> expectedPhaseDtos = Arrays.asList(
                 new PhaseDto(phase1.getPhaseName(), phase1.getPhaseValue()),


### PR DESCRIPTION
1. Remove query mapping and unused JPA methods from repository classes. 
2. Queries with 'UPPER' SQL statement excluded.
3. Queries fetching data from more than one table excluded.