### PR TITLE
Require explicit year input before chatbot GDHM data tools return figures.

### DIFF
--- a/src/main/java/it/gdhi/service/BedrockToolsService.java
+++ b/src/main/java/it/gdhi/service/BedrockToolsService.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 
 import static it.gdhi.utils.ApplicationConstants.defaultLimit;
 import static it.gdhi.utils.LanguageCode.USER_LANGUAGE;
-import static it.gdhi.utils.Util.getCurrentYear;
 
 @Service
 @Transactional(readOnly = true)
@@ -66,35 +65,22 @@ public class BedrockToolsService {
     public BedrockToolResponse<BedrockCountrySummaryData> getCountrySummary(
             String countryId, String year, String languageHeader) {
         LanguageCode languageCode = LanguageCode.getValueFor(languageHeader);
-        CountryPhase latestCountryPhase = null;
-        String effectiveYear = year;
-        if (!StringUtils.hasText(effectiveYear)) {
-            latestCountryPhase = countryPhaseRepository.findLatestByCountryId(countryId);
-            effectiveYear = latestCountryPhase == null ? resolveYear(year) : latestCountryPhase.getYear();
-        }
+        String effectiveYear = requireCountryYear(year, countryId, "country summary data");
         CountrySummaryDto dto = countryService.fetchCountrySummary(countryId, effectiveYear);
         translateSummaryCountryName(dto, countryId, languageCode);
-        Integer countryPhase = latestCountryPhase == null
-                ? fetchCountryOverallPhaseValue(countryId, effectiveYear)
-                : latestCountryPhase.getCountryOverallPhase();
+        Integer countryPhase = fetchCountryOverallPhaseValue(countryId, effectiveYear);
         BedrockCountrySummaryData data = BedrockCountrySummaryData.from(dto, effectiveYear, countryPhase);
         return BedrockToolResponse.ok("getCountrySummary",
-                "Fetched country summary without personal contact details, including overall phase for the requested year",
+                "Fetched country summary without personal contact details, including overall phase "
+                        + "for the requested year",
                 filters("countryId", countryId, "year", effectiveYear, "language", languageCode.name()), data);
     }
 
     public BedrockToolResponse<BedrockCountryPhaseData> getCountryPhase(
             String countryId, String year, String languageHeader) {
         LanguageCode languageCode = LanguageCode.getValueFor(languageHeader);
-        CountryPhase countryPhase = null;
-        String effectiveYear = year;
-        if (!StringUtils.hasText(effectiveYear)) {
-            countryPhase = countryPhaseRepository.findLatestByCountryId(countryId);
-            effectiveYear = countryPhase == null ? resolveYear(year) : countryPhase.getYear();
-        }
-        BedrockCountryPhaseData data = countryPhase == null
-                ? buildCountryPhaseData(countryId, effectiveYear, languageCode)
-                : buildCountryPhaseData(countryId, effectiveYear, languageCode, countryPhase);
+        String effectiveYear = requireCountryYear(year, countryId, "country phase data");
+        BedrockCountryPhaseData data = buildCountryPhaseData(countryId, effectiveYear, languageCode);
         return BedrockToolResponse.ok("getCountryPhase", "Fetched country overall phase",
                 filters("countryId", countryId, "year", effectiveYear, "language", languageCode.name()), data);
     }
@@ -102,19 +88,9 @@ public class BedrockToolsService {
     public BedrockToolResponse<CountryHealthScoreDto> getCountryHealthIndicators(
             String countryId, String year, String languageHeader) {
         LanguageCode languageCode = LanguageCode.getValueFor(languageHeader);
-        CountryPhase latestCountryPhase = null;
-        String effectiveYear = year;
-        CountryHealthScoreDto dto;
-        if (StringUtils.hasText(effectiveYear)) {
-            dto = countryHealthIndicatorService.fetchCountryHealthScore(countryId, languageCode, effectiveYear);
-        }
-        else {
-            latestCountryPhase = countryPhaseRepository.findLatestByCountryId(countryId);
-            effectiveYear = latestCountryPhase == null ? resolveYear(year) : latestCountryPhase.getYear();
-            dto = latestCountryPhase == null
-                    ? countryHealthIndicatorService.fetchCountryHealthScore(countryId, languageCode, effectiveYear)
-                    : countryHealthIndicatorService.fetchLatestCountryHealthScore(countryId, languageCode);
-        }
+        String effectiveYear = requireCountryYear(year, countryId, "country health indicator scores");
+        CountryHealthScoreDto dto = countryHealthIndicatorService.fetchCountryHealthScore(countryId, languageCode,
+                effectiveYear);
         return BedrockToolResponse.ok("getCountryHealthIndicators", "Fetched country health indicators",
                 filters("countryId", countryId, "year", effectiveYear, "language", languageCode.name()), dto);
     }
@@ -124,23 +100,12 @@ public class BedrockToolsService {
         String effectiveRegionId = RegionAlias.normalize(regionId);
         requireAnyFilter("global health indicators", categoryId, phase, effectiveRegionId);
         LanguageCode languageCode = LanguageCode.getValueFor(languageHeader);
-        String effectiveYear = year;
-        GlobalHealthScoreDto dto;
-        if (StringUtils.hasText(effectiveYear)) {
-            dto = effectiveRegionId == null
-                    ? countryHealthIndicatorService.getGlobalHealthIndicator(categoryId, phase, languageCode,
-                            effectiveYear)
-                    : regionService.fetchRegionalHealthScores(categoryId, effectiveRegionId, languageCode,
-                            effectiveYear);
-        }
-        else if (effectiveRegionId == null) {
-            effectiveYear = "latest";
-            dto = countryHealthIndicatorService.getLatestGlobalHealthIndicator(categoryId, phase, languageCode);
-        }
-        else {
-            effectiveYear = resolveLatestRegionalYear(effectiveRegionId);
-            dto = regionService.fetchRegionalHealthScores(categoryId, effectiveRegionId, languageCode, effectiveYear);
-        }
+        String effectiveYear = requireYear(year, "global health indicator data");
+        GlobalHealthScoreDto dto = effectiveRegionId == null
+                ? countryHealthIndicatorService.getGlobalHealthIndicator(categoryId, phase, languageCode,
+                        effectiveYear)
+                : regionService.fetchRegionalHealthScores(categoryId, effectiveRegionId, languageCode,
+                        effectiveYear);
         return BedrockToolResponse.ok("getGlobalHealthIndicators", "Fetched global health indicators",
                 filters("categoryId", categoryId, "phase", phase, "regionId", effectiveRegionId, "year", effectiveYear,
                         "language", languageCode.name()), dto);
@@ -150,16 +115,9 @@ public class BedrockToolsService {
             Integer categoryId, Integer phase, String year, String languageHeader) {
         requireAnyFilter("country score comparisons", categoryId, phase);
         LanguageCode languageCode = LanguageCode.getValueFor(languageHeader);
-        String effectiveYear = year;
-        CountriesHealthScoreDto dto;
-        if (StringUtils.hasText(effectiveYear)) {
-            dto = countryHealthIndicatorService.fetchCountriesHealthScores(categoryId, phase, languageCode,
-                    effectiveYear);
-        }
-        else {
-            effectiveYear = "latest";
-            dto = countryHealthIndicatorService.fetchCountriesLatestHealthScores(categoryId, phase, languageCode);
-        }
+        String effectiveYear = requireYear(year, "country health indicator score comparisons");
+        CountriesHealthScoreDto dto = countryHealthIndicatorService.fetchCountriesHealthScores(categoryId, phase,
+                languageCode, effectiveYear);
         return BedrockToolResponse.ok("getCountriesHealthIndicatorScores", "Fetched countries health indicator scores",
                 filters("categoryId", categoryId, "phase", phase, "year", effectiveYear, "language",
                         languageCode.name()), dto);
@@ -213,15 +171,9 @@ public class BedrockToolsService {
         }
 
         LanguageCode languageCode = LanguageCode.getValueFor(languageHeader);
-        String effectiveYear = year;
-        List<CountryPhase> countryPhases;
-        if (StringUtils.hasText(effectiveYear)) {
-            countryPhases = countryPhaseRepository.findByCountryPhaseIdYearAndCountryOverallPhase(effectiveYear, phase);
-        }
-        else {
-            effectiveYear = "latest";
-            countryPhases = countryPhaseRepository.findByLatestTrueAndCountryOverallPhase(phase);
-        }
+        String effectiveYear = requireYear(year, "countries by phase data");
+        List<CountryPhase> countryPhases = countryPhaseRepository.findByCountryPhaseIdYearAndCountryOverallPhase(
+                effectiveYear, phase);
         List<BedrockCountryPhaseData> countries = countryPhases.stream()
                 .map(countryPhase -> buildCountryPhaseData(countryPhase.getCountryPhaseId().getCountryId(),
                         countryPhase.getYear(),
@@ -246,6 +198,7 @@ public class BedrockToolsService {
             Integer limit) {
         String effectiveRegionId = RegionAlias.normalize(regionId);
         String effectiveDirection = StringUtils.hasText(direction) ? direction : "advanced";
+        requireYearRange(startYear, endYear, "country phase trend analysis");
         List<BedrockCountryPhaseTrendData> trends = gdhmAnalyticsService.analyzeCountryPhaseTrends(
                 effectiveRegionId, countryId, categoryId, indicatorId, startYear, endYear, effectiveDirection,
                 minSubmissionYears, limit);
@@ -272,12 +225,13 @@ public class BedrockToolsService {
             Integer secondaryMaxPhase) {
         String effectiveRegionId = RegionAlias.normalize(regionId);
         String effectiveSort = StringUtils.hasText(sort) ? sort : "highest";
+        String effectiveYear = requireYear(year, "country ranking data");
         List<BedrockCountryRankingData> rankings = gdhmAnalyticsService.rankCountries(
-                effectiveRegionId, countryIds, categoryId, indicatorId, year, minPhase, maxPhase, effectiveSort, limit,
-                secondaryCategoryId, secondaryIndicatorId, secondaryMinPhase, secondaryMaxPhase);
+                effectiveRegionId, countryIds, categoryId, indicatorId, effectiveYear, minPhase, maxPhase,
+                effectiveSort, limit, secondaryCategoryId, secondaryIndicatorId, secondaryMinPhase, secondaryMaxPhase);
         return BedrockToolResponse.ok("rankCountries", "Ranked countries by GDHM score filters",
                 filters("regionId", effectiveRegionId, "countryId", countryIds, "categoryId", categoryId,
-                        "indicatorId", indicatorId, "year", year, "minPhase", minPhase, "maxPhase", maxPhase,
+                        "indicatorId", indicatorId, "year", effectiveYear, "minPhase", minPhase, "maxPhase", maxPhase,
                         "sort", effectiveSort, "limit", limit, "secondaryCategoryId", secondaryCategoryId,
                         "secondaryIndicatorId", secondaryIndicatorId, "secondaryMinPhase", secondaryMinPhase,
                         "secondaryMaxPhase", secondaryMaxPhase),
@@ -293,18 +247,20 @@ public class BedrockToolsService {
         if (!StringUtils.hasText(analysisType)) {
             throw new IllegalArgumentException("Missing required parameter: analysisType");
         }
+        String effectiveYear = requireYear(year, "data completeness analysis");
         String effectiveRegionId = RegionAlias.normalize(regionId);
         List<BedrockDataCompletenessData> data = gdhmAnalyticsService.analyzeDataCompleteness(
-                analysisType, year, effectiveRegionId, phase, limit);
+                analysisType, effectiveYear, effectiveRegionId, phase, limit);
         return BedrockToolResponse.ok("analyzeDataCompleteness", "Analyzed GDHM data completeness",
-                filters("analysisType", analysisType, "year", year, "regionId", effectiveRegionId, "phase", phase,
-                        "limit", limit),
+                filters("analysisType", analysisType, "year", effectiveYear, "regionId", effectiveRegionId, "phase",
+                        phase, "limit", limit),
                 data);
     }
 
     public BedrockToolResponse<?> executeApiInvocation(ApiInvocationInput apiInvocationInput) {
         if (!"GET".equalsIgnoreCase(apiInvocationInput.httpMethod())) {
-            throw new IllegalArgumentException("Unsupported Bedrock tool HTTP method: " + apiInvocationInput.httpMethod());
+            throw new IllegalArgumentException("Unsupported Bedrock tool HTTP method: "
+                    + apiInvocationInput.httpMethod());
         }
 
         Map<String, List<String>> parameters = groupParameters(apiInvocationInput.parameters());
@@ -392,12 +348,19 @@ public class BedrockToolsService {
     }
 
     public BedrockToolResponse<Map<String, Object>> validationError(Exception ex) {
+        String message = StringUtils.hasText(ex.getMessage())
+                ? ex.getMessage()
+                : "The request needs more specific filters before I can safely run it.";
+        Map<String, Object> data = filters("error", message);
+        if (ex instanceof MissingYearException missingYearException) {
+            data.putAll(missingYearException.details());
+        }
         return new BedrockToolResponse<>(
                 "validation",
                 "error",
-                "The request needs more specific filters before I can safely run it.",
+                message,
                 filters(),
-                filters("error", ex.getMessage()),
+                data,
                 Instant.now()
         );
     }
@@ -411,17 +374,6 @@ public class BedrockToolsService {
                 filters("error", "An internal error occurred."),
                 Instant.now()
         );
-    }
-
-    private String resolveYear(String year) {
-        if (year != null && !year.isBlank()) {
-            return year;
-        }
-        String defaultYear = defaultYearDataService.fetchDefaultYear();
-        if (defaultYear != null && !defaultYear.isBlank()) {
-            return defaultYear;
-        }
-        return getCurrentYear();
     }
 
     private Map<String, List<String>> groupParameters(List<ApiParameter> parameters) {
@@ -503,21 +455,69 @@ public class BedrockToolsService {
         });
         if (!hasFilter) {
             throw new IllegalArgumentException(
-                    "Please ask for a narrower " + queryName + " query. Include at least one specific filter such as category, phase, or region.");
+                    "Please ask for a narrower " + queryName + " query. Include at least one specific filter such as "
+                            + "category, phase, or region.");
         }
+    }
+
+    private String requireYear(String year, String queryName) {
+        if (StringUtils.hasText(year)) {
+            return year.trim();
+        }
+        throw new IllegalArgumentException("A year is required for " + queryName
+                + ". Ask the user which year they want before returning GDHM figures.");
+    }
+
+    private String requireCountryYear(String year, String countryId, String queryName) {
+        if (StringUtils.hasText(year)) {
+            return year.trim();
+        }
+        List<String> countryYears = countryPhaseRepository.findByCountryPhaseIdOrderByYearDesc(countryId,
+                defaultLimit);
+        List<String> availableYears = sortYears(countryYears == null ? List.of() : countryYears);
+        String countryName = countryName(countryId);
+        String countryLabel = StringUtils.hasText(countryName) ? countryName : countryId;
+        String message = availableYears.isEmpty()
+                ? "A year is required for " + queryName + ". Ask the user which year they want before returning "
+                        + "GDHM figures."
+                : "A year is required for " + queryName + ". Available years for " + countryLabel + " are: "
+                        + String.join(", ", availableYears) + ". Ask the user which year they want before returning "
+                        + "GDHM figures.";
+        throw new MissingYearException(message, filters(
+                "missingParameter", "year",
+                "countryId", countryId,
+                "countryName", countryName,
+                "availableYears", availableYears));
+    }
+
+    private void requireYearRange(String startYear, String endYear, String queryName) {
+        if (StringUtils.hasText(startYear) || StringUtils.hasText(endYear)) {
+            return;
+        }
+        throw new IllegalArgumentException("A year or year range is required for " + queryName
+                + ". Ask the user which year or range they want before returning GDHM figures.");
     }
 
     private Integer fetchCountryOverallPhaseValue(String countryId, String year) {
-        CountryPhase countryPhase = countryPhaseRepository.findByCountryPhaseIdCountryIdAndCountryPhaseIdYear(countryId, year);
+        CountryPhase countryPhase = countryPhaseRepository.findByCountryPhaseIdCountryIdAndCountryPhaseIdYear(
+                countryId, year);
         return countryPhase == null ? null : countryPhase.getCountryOverallPhase();
     }
 
-    private String resolveLatestRegionalYear(String regionId) {
-        List<String> years = regionService.fetchYearsForARegion(regionId, 1);
-        if (years != null && !years.isEmpty() && StringUtils.hasText(years.get(0))) {
-            return years.get(0);
+    private String countryName(String countryId) {
+        Country country = countryRepository.findById(countryId);
+        return country == null ? null : country.getName();
+    }
+
+    private List<String> sortYears(List<String> years) {
+        return years.stream().sorted((left, right) -> yearSortValue(left).compareTo(yearSortValue(right))).toList();
+    }
+
+    private Integer yearSortValue(String year) {
+        if (year != null && year.matches("\\d{4}")) {
+            return Integer.valueOf(year);
         }
-        return resolveYear(null);
+        return 0;
     }
 
     private void translateSummaryCountryName(CountrySummaryDto dto, String countryId, LanguageCode languageCode) {
@@ -532,7 +532,8 @@ public class BedrockToolsService {
     }
 
     private BedrockCountryPhaseData buildCountryPhaseData(String countryId, String year, LanguageCode languageCode) {
-        CountryPhase countryPhase = countryPhaseRepository.findByCountryPhaseIdCountryIdAndCountryPhaseIdYear(countryId, year);
+        CountryPhase countryPhase = countryPhaseRepository.findByCountryPhaseIdCountryIdAndCountryPhaseIdYear(
+                countryId, year);
         return buildCountryPhaseData(countryId, year, languageCode, countryPhase);
     }
 
@@ -560,5 +561,19 @@ public class BedrockToolsService {
                 countryOverallPhase,
                 BedrockCountryPhaseData.phaseLabelFor(countryOverallPhase)
         );
+    }
+
+    private static class MissingYearException extends IllegalArgumentException {
+
+        private final Map<String, Object> details;
+
+        MissingYearException(String message, Map<String, Object> details) {
+            super(message);
+            this.details = details;
+        }
+
+        private Map<String, Object> details() {
+            return details;
+        }
     }
 }

--- a/src/test/java/it/gdhi/service/BedrockToolsServiceTest.java
+++ b/src/test/java/it/gdhi/service/BedrockToolsServiceTest.java
@@ -3,13 +3,9 @@ package it.gdhi.service;
 import it.gdhi.ai.dto.BedrockCountrySummaryData;
 import it.gdhi.ai.dto.BedrockToolResponse;
 import it.gdhi.ai.dto.BedrockCountryPhaseData;
-import it.gdhi.ai.dto.BedrockCountryPhaseTrendData;
-import it.gdhi.ai.dto.BedrockCountryRankingData;
-import it.gdhi.ai.dto.BedrockDataCompletenessData;
 import it.gdhi.dto.CountriesHealthScoreDto;
 import it.gdhi.dto.GlobalHealthScoreDto;
 import it.gdhi.dto.PhaseDto;
-import it.gdhi.dto.RegionCountriesDto;
 import it.gdhi.dto.CountryHealthScoreDto;
 import it.gdhi.dto.CountrySummaryDto;
 import it.gdhi.internationalization.service.CountryNameTranslator;
@@ -22,15 +18,19 @@ import it.gdhi.utils.LanguageCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.bedrockagentruntime.model.ApiInvocationInput;
 import software.amazon.awssdk.services.bedrockagentruntime.model.ApiParameter;
 
 import java.util.List;
+import java.util.Map;
 
+import static it.gdhi.utils.ApplicationConstants.defaultLimit;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -96,54 +96,35 @@ public class BedrockToolsServiceTest {
     }
 
     @Test
-    public void shouldUseLatestCountryPhaseYearForCountrySummaryWhenYearIsMissing() {
-        CountryPhase latestPhase = new CountryPhase("KEN", 3, "2024", true);
-        CountrySummaryDto summary = CountrySummaryDto.builder()
-                .countryId("KEN")
-                .countryName("Kenya")
-                .countryAlpha2Code("KE")
-                .summary("Summary")
-                .build();
-        when(countryPhaseRepository.findLatestByCountryId("KEN")).thenReturn(latestPhase);
-        when(countryService.fetchCountrySummary("KEN", "2024")).thenReturn(summary);
-
-        BedrockToolResponse<BedrockCountrySummaryData> response = service.getCountrySummary("KEN", null, "en");
-
-        assertEquals("2024", response.filters().get("year"));
-        assertEquals("2024", response.data().year());
-        assertEquals(3, response.data().countryPhase());
-        verify(defaultYearDataService, never()).fetchDefaultYear();
-    }
-
-    @Test
-    public void shouldUseLatestCountryPhaseForCountryPhaseWhenYearIsMissing() {
-        CountryPhase latestPhase = new CountryPhase("KEN", 3, "2024", true);
-        when(countryPhaseRepository.findLatestByCountryId("KEN")).thenReturn(latestPhase);
+    public void shouldRejectCountrySummaryWhenYearIsMissing() {
+        when(countryPhaseRepository.findByCountryPhaseIdOrderByYearDesc("KEN", defaultLimit))
+                .thenReturn(List.of("2026", "2025", "2024"));
         when(countryRepository.findById("KEN")).thenReturn(new Country("KEN", "Kenya", null, "KE"));
 
-        BedrockToolResponse<BedrockCountryPhaseData> response = service.getCountryPhase("KEN", null, "en");
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.getCountrySummary("KEN", null, "en"));
 
-        assertEquals("2024", response.filters().get("year"));
-        assertEquals("2024", response.data().year());
-        assertEquals(3, response.data().countryPhase());
-        verify(defaultYearDataService, never()).fetchDefaultYear();
+        assertTrue(ex.getMessage().contains("country summary data"));
+        assertTrue(ex.getMessage().contains("Available years for Kenya are: 2024, 2025, 2026"));
+        verify(countryPhaseRepository, never()).findLatestByCountryId("KEN");
     }
 
     @Test
-    public void shouldUseLatestCountryHealthIndicatorsWhenYearIsMissing() {
-        CountryPhase latestPhase = new CountryPhase("KEN", 3, "2024", true);
-        CountryHealthScoreDto healthScore = new CountryHealthScoreDto();
-        when(countryPhaseRepository.findLatestByCountryId("KEN")).thenReturn(latestPhase);
-        when(countryHealthIndicatorService.fetchLatestCountryHealthScore("KEN", LanguageCode.en))
-                .thenReturn(healthScore);
+    public void shouldRejectCountryPhaseWhenYearIsMissing() {
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.getCountryPhase("KEN", null, "en"));
 
-        BedrockToolResponse<CountryHealthScoreDto> response =
-                service.getCountryHealthIndicators("KEN", null, "en");
+        assertTrue(ex.getMessage().contains("country phase data"));
+        verify(countryPhaseRepository, never()).findLatestByCountryId("KEN");
+    }
 
-        assertEquals("2024", response.filters().get("year"));
-        assertEquals(healthScore, response.data());
-        verify(countryHealthIndicatorService).fetchLatestCountryHealthScore("KEN", LanguageCode.en);
-        verify(defaultYearDataService, never()).fetchDefaultYear();
+    @Test
+    public void shouldRejectCountryHealthIndicatorsWhenYearIsMissing() {
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.getCountryHealthIndicators("KEN", null, "en"));
+
+        assertTrue(ex.getMessage().contains("country health indicator scores"));
+        verify(countryHealthIndicatorService, never()).fetchLatestCountryHealthScore("KEN", LanguageCode.en);
     }
 
     @Test
@@ -155,13 +136,23 @@ public class BedrockToolsServiceTest {
                         ApiParameter.builder().name("regionId").value("African region").type("string").build(),
                         ApiParameter.builder().name("categoryId").value("1").type("integer").build(),
                         ApiParameter.builder().name("indicatorId").value("4").type("integer").build(),
+                        ApiParameter.builder().name("startYear").value("2020").type("string").build(),
+                        ApiParameter.builder().name("endYear").value("2024").type("string").build(),
                         ApiParameter.builder().name("direction").value("advanced").type("string").build()))
                 .build();
 
         service.executeApiInvocation(input);
 
-        verify(gdhmAnalyticsService).analyzeCountryPhaseTrends("AFRO", null, 1, 4, null, null,
+        verify(gdhmAnalyticsService).analyzeCountryPhaseTrends("AFRO", null, 1, 4, "2020", "2024",
                 "advanced", null, null);
+    }
+
+    @Test
+    public void shouldRejectCountryPhaseTrendWhenYearRangeIsMissing() {
+        IllegalArgumentException ex = assertRequiresYearRange(() -> service.analyzeCountryPhaseTrends(
+                "AFRO", null, 1, 4, null, null, "advanced", null, null));
+
+        assertTrue(ex.getMessage().contains("country phase trend analysis"));
     }
 
     @Test
@@ -174,13 +165,22 @@ public class BedrockToolsServiceTest {
                         ApiParameter.builder().name("countryId").value("ZAF").type("string").build(),
                         ApiParameter.builder().name("countryIds").value("KEN,GHA").type("string").build(),
                         ApiParameter.builder().name("categoryId").value("5").type("integer").build(),
+                        ApiParameter.builder().name("year").value("2024").type("string").build(),
                         ApiParameter.builder().name("sort").value("highest").type("string").build()))
                 .build();
 
         service.executeApiInvocation(input);
 
-        verify(gdhmAnalyticsService).rankCountries(null, List.of("BRA", "ZAF", "KEN", "GHA"), 5, null, null,
+        verify(gdhmAnalyticsService).rankCountries(null, List.of("BRA", "ZAF", "KEN", "GHA"), 5, null, "2024",
                 null, null, "highest", null, null, null, null, null);
+    }
+
+    @Test
+    public void shouldRejectCountryRankingWhenYearIsMissing() {
+        IllegalArgumentException ex = assertRequiresYear(() -> service.rankCountries(null, List.of("KEN"),
+                5, null, null, null, null, "highest", null, null, null, null, null));
+
+        assertTrue(ex.getMessage().contains("country ranking data"));
     }
 
     @Test
@@ -223,24 +223,20 @@ public class BedrockToolsServiceTest {
     }
 
     @Test
-    public void shouldUseLatestGlobalHealthIndicatorsWhenYearIsMissingAndNoRegion() {
-        GlobalHealthScoreDto dto = GlobalHealthScoreDto.builder().overAllScore(3).build();
-        when(countryHealthIndicatorService.getLatestGlobalHealthIndicator(1, null, LanguageCode.en)).thenReturn(dto);
+    public void shouldRejectGlobalHealthIndicatorsWhenYearIsMissing() {
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.getGlobalHealthIndicators(1, null, null, null, "en"));
 
-        BedrockToolResponse<GlobalHealthScoreDto> response = service.getGlobalHealthIndicators(1, null, null, null,
-                "en");
-
-        assertEquals("latest", response.filters().get("year"));
-        assertEquals(dto, response.data());
+        assertTrue(ex.getMessage().contains("global health indicator data"));
+        verify(countryHealthIndicatorService, never()).getLatestGlobalHealthIndicator(1, null, LanguageCode.en);
     }
 
     @Test
-    public void shouldResolveLatestRegionalYearWhenYearIsMissingForRegionGlobalIndicators() {
+    public void shouldUseRequestedRegionalYearForRegionGlobalIndicators() {
         GlobalHealthScoreDto dto = GlobalHealthScoreDto.builder().overAllScore(2).build();
-        when(regionService.fetchYearsForARegion("AFRO", 1)).thenReturn(List.of("2024"));
         when(regionService.fetchRegionalHealthScores(1, "AFRO", LanguageCode.en, "2024")).thenReturn(dto);
 
-        BedrockToolResponse<GlobalHealthScoreDto> response = service.getGlobalHealthIndicators(1, null, "AFRO", null,
+        BedrockToolResponse<GlobalHealthScoreDto> response = service.getGlobalHealthIndicators(1, null, "AFRO", "2024",
                 "en");
 
         assertEquals("2024", response.filters().get("year"));
@@ -248,25 +244,45 @@ public class BedrockToolsServiceTest {
     }
 
     @Test
-    public void shouldUseLatestCountriesHealthScoresWhenYearIsMissing() {
+    public void shouldUseRequestedYearForCountriesHealthScores() {
         CountriesHealthScoreDto dto = new CountriesHealthScoreDto(List.of(new CountryHealthScoreDto()));
-        when(countryHealthIndicatorService.fetchCountriesLatestHealthScores(1, null, LanguageCode.en)).thenReturn(dto);
+        when(countryHealthIndicatorService.fetchCountriesHealthScores(1, null, LanguageCode.en, "2024"))
+                .thenReturn(dto);
 
         BedrockToolResponse<CountriesHealthScoreDto> response = service.getCountriesHealthIndicatorScores(1, null,
-                null, "en");
+                "2024", "en");
 
-        assertEquals("latest", response.filters().get("year"));
+        assertEquals("2024", response.filters().get("year"));
         assertEquals(dto, response.data());
+    }
+
+    @Test
+    public void shouldRejectCountriesHealthScoresWhenYearIsMissing() {
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.getCountriesHealthIndicatorScores(1, null, null, "en"));
+
+        assertTrue(ex.getMessage().contains("country health indicator score comparisons"));
+        verify(countryHealthIndicatorService, never()).fetchCountriesLatestHealthScores(1, null, LanguageCode.en);
+    }
+
+    @Test
+    public void shouldRejectCountriesByPhaseWhenYearIsMissing() {
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.listCountriesByPhase(2, null, "en"));
+
+        assertTrue(ex.getMessage().contains("countries by phase data"));
+        verify(countryPhaseRepository, never()).findByLatestTrueAndCountryOverallPhase(2);
     }
 
     @Test
     public void shouldUseTranslatedNameWhenBuildingCountryPhaseData() {
         CountryPhase phase = new CountryPhase("KEN", 2, "2024", true);
-        when(countryPhaseRepository.findLatestByCountryId("KEN")).thenReturn(phase);
+        when(countryPhaseRepository.findByCountryPhaseIdCountryIdAndCountryPhaseIdYear("KEN", "2024"))
+                .thenReturn(phase);
         when(countryRepository.findById("KEN")).thenReturn(new Country("KEN", "Kenya", null, "KE"));
         when(countryNameTranslator.getCountryTranslationForLanguage(LanguageCode.fr, "KEN")).thenReturn("Kenya-fr");
 
-        BedrockToolResponse<BedrockCountryPhaseData> response = service.getCountryPhase("KEN", null, "fr");
+        BedrockToolResponse<BedrockCountryPhaseData> response = service.getCountryPhase("KEN", "2024", "fr");
 
         assertEquals("Kenya-fr", response.data().countryName());
     }
@@ -318,16 +334,26 @@ public class BedrockToolsServiceTest {
                 .httpMethod("GET")
                 .apiPath("/analytics/data-completeness")
                 .parameters(List.of(
-                        ApiParameter.builder().name("analysisType").value("missing_country_data").type("string").build(),
+                        ApiParameter.builder().name("analysisType").value("missing_country_data").type("string")
+                                .build(),
                         ApiParameter.builder().name("regionId").value("AFRO").type("string").build(),
+                        ApiParameter.builder().name("year").value("2024").type("string").build(),
                         ApiParameter.builder().name("limit").value("10").type("integer").build()))
                 .build();
-        when(gdhmAnalyticsService.analyzeDataCompleteness("missing_country_data", null, "AFRO", null, 10))
+        when(gdhmAnalyticsService.analyzeDataCompleteness("missing_country_data", "2024", "AFRO", null, 10))
                 .thenReturn(List.of());
 
         service.executeApiInvocation(input);
 
-        verify(gdhmAnalyticsService).analyzeDataCompleteness("missing_country_data", null, "AFRO", null, 10);
+        verify(gdhmAnalyticsService).analyzeDataCompleteness("missing_country_data", "2024", "AFRO", null, 10);
+    }
+
+    @Test
+    public void shouldRejectDataCompletenessWhenYearIsMissing() {
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.analyzeDataCompleteness("missing_country_data", null, "AFRO", null, 10));
+
+        assertTrue(ex.getMessage().contains("data completeness analysis"));
     }
 
     @Test
@@ -341,5 +367,36 @@ public class BedrockToolsServiceTest {
         assertEquals(1, service.getPhases().data().size());
         assertEquals(1, service.listRegions("en").data().size());
         assertEquals(0, service.getHealthIndicatorOptions("en").data().size());
+    }
+
+    @Test
+    public void shouldReturnSpecificValidationMessage() {
+        when(countryPhaseRepository.findByCountryPhaseIdOrderByYearDesc("KEN", defaultLimit))
+                .thenReturn(List.of("2026", "2025", "2024"));
+        when(countryRepository.findById("KEN")).thenReturn(new Country("KEN", "Kenya", null, "KE"));
+        IllegalArgumentException ex = assertRequiresYear(
+                () -> service.getCountrySummary("KEN", null, "en"));
+
+        BedrockToolResponse<?> response = service.validationError(ex);
+        Map<?, ?> data = (Map<?, ?>) response.data();
+
+        assertEquals(ex.getMessage(), response.message());
+        assertEquals("KEN", data.get("countryId"));
+        assertEquals("Kenya", data.get("countryName"));
+        assertEquals(List.of("2024", "2025", "2026"), data.get("availableYears"));
+    }
+
+    private IllegalArgumentException assertRequiresYear(Executable executable) {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, executable);
+        assertTrue(ex.getMessage().contains("A year is required"));
+        assertTrue(ex.getMessage().contains("Ask the user which year they want"));
+        return ex;
+    }
+
+    private IllegalArgumentException assertRequiresYearRange(Executable executable) {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, executable);
+        assertTrue(ex.getMessage().contains("A year or year range is required"));
+        assertTrue(ex.getMessage().contains("Ask the user which year or range they want"));
+        return ex;
     }
 }


### PR DESCRIPTION
## Summary
- Require explicit year input before chatbot GDHM data tools return figures.
- Require a start/end year for trend analysis instead of defaulting to all available history.
- Remove Bedrock tool-layer fallback to latest-per-country data for no-year requests.
- Return specific validation messages so the AI reprompts for the missing year.
- Update tests for missing-year rejection and explicit-year behavior.

